### PR TITLE
avoid dependency on which

### DIFF
--- a/execute-all.sh
+++ b/execute-all.sh
@@ -247,7 +247,7 @@ update_java_path() {
     __javahome="$__javapath"
     JAVA_FOUND=true
   else
-    readonly __JAVALINK=$(which java)
+    readonly __JAVALINK=$(command -v java)
     if [[ "$__JAVALINK" == "" ]]; then
       echo "[!] Java not found in system"
     else


### PR DESCRIPTION
This uses the shell's support for determining the path for a command,
avoiding an unnecessary obsolete dependency. The `which` command should
be avoided since it isn't properly aligned with the shell.