### PR TITLE
add missing bytecode section for marlin/sailfish

### DIFF
--- a/marlin/config.json
+++ b/marlin/config.json
@@ -658,6 +658,7 @@
           "libsensorndkbridge",
           "android.hardware.drm@1.2-service.clearkey"
         ],
+        "product-bytecode": [],
         "new-modules": [],
         "dep-dso": [],
         "BoardConfigVendor": [],

--- a/sailfish/config.json
+++ b/sailfish/config.json
@@ -658,6 +658,7 @@
           "libsensorndkbridge",
           "android.hardware.drm@1.2-service.clearkey"
         ],
+        "product-bytecode": [],
         "new-modules": [],
         "dep-dso": [],
         "BoardConfigVendor": [],


### PR DESCRIPTION
fails with jq error otherwise:
```
jq: error (at /home/ubuntu/rattlesnake-os/vendor/android-prepare-vendor/sailfish/config.json:969): Cannot iterate over null (null) [-] json raw string array parse failed
```