### PR TITLE
Sort *.so files for reproducibility

### DIFF
--- a/scripts/generate-vendor.sh
+++ b/scripts/generate-vendor.sh
@@ -735,7 +735,7 @@ gen_mk_for_bytecode() {
       while read -r lib
       do
         echo "$lib" | sed "s#$inDir/##" >> "$RUNTIME_EXTRA_BLOBS_LIST"
-      done < <(find "$appDir/lib" -type f -iname '*.so')
+      done < <(find "$appDir/lib" -type f -iname '*.so' | sort)
 
       # Some prebuilt APKs have also prebuilt JNI libs that are stored under
       # system-wide lib directories, with app directory containing a symlink to.
@@ -759,7 +759,7 @@ gen_mk_for_bytecode() {
         apk_lib_slinks+="$(gen_apk_dso_symlink "$dsoName" "$dsoMName" "$dsoRoot" \
                            "$lcMPath/$pkgName" "$arch")"
         echo "${dsoRoot:1}/$dsoName" >> "$APK_SYSTEM_LIB_BLOBS_LIST"
-      done < <(find -L "$appDir/lib" -type l -iname '*.so')
+      done < <(find -L "$appDir/lib" -type l -iname '*.so' | sort)
     fi
 
     {


### PR DESCRIPTION
Fixes reproducibility of android-prepare-vendor output.
Other invocations of `find` in this file already sort their output as
well.

Here's the before/after for `crosshatch`:
```diff
diff -r -u /nix/store/s4kp7rw8prpyla1i51mwpybxddm9id0l-vendor-files-crosshatch/vendor/google_devices/crosshatch/Android.mk /nix/store/cvgzlrsgx5q7y6r5c4g8q1d8g5rfaaz0-vendor-files-crosshatch/vendor/google_devices/crosshatch/Android.mk
--- /nix/store/s4kp7rw8prpyla1i51mwpybxddm9id0l-vendor-files-crosshatch/vendor/google_devices/crosshatch/Android.mk	1969-12-31 19:00:01.000000000 -0500
+++ /nix/store/cvgzlrsgx5q7y6r5c4g8q1d8g5rfaaz0-vendor-files-crosshatch/vendor/google_devices/crosshatch/Android.mk	1969-12-31 19:00:01.000000000 -0500
@@ -101,20 +101,20 @@
 LOCAL_MODULE_OWNER := google
 LOCAL_MODULE_PATH := $(PRODUCT_OUT)/$(TARGET_COPY_OUT_SYSTEM)/app
 LOCAL_SRC_FILES := proprietary/app/ims/ims.apk
-LOCAL_REQUIRED_MODULES := libimscamera_jni_64.so libimsmedia_jni_64.so
+LOCAL_REQUIRED_MODULES := libimsmedia_jni_64.so libimscamera_jni_64.so
 LOCAL_CERTIFICATE := platform
 LOCAL_MODULE_CLASS := APPS
 LOCAL_MODULE_SUFFIX := $(COMMON_ANDROID_PACKAGE_SUFFIX)
 include $(BUILD_PREBUILT)
 
 include $(CLEAR_VARS)
-LOCAL_MODULE := libimscamera_jni_64.so
+LOCAL_MODULE := libimsmedia_jni_64.so
 LOCAL_MODULE_CLASS := FAKE
 LOCAL_MODULE_TAGS := optional
 LOCAL_MODULE_OWNER := google
 include $(BUILD_SYSTEM)/base_rules.mk
-$(LOCAL_BUILT_MODULE): TARGET := /system/lib64/libimscamera_jni.so
-$(LOCAL_BUILT_MODULE): SYMLINK := $(PRODUCT_OUT)/$(TARGET_COPY_OUT_SYSTEM)/app/ims/lib/arm64/libimscamera_jni.so
+$(LOCAL_BUILT_MODULE): TARGET := /system/lib64/libimsmedia_jni.so
+$(LOCAL_BUILT_MODULE): SYMLINK := $(PRODUCT_OUT)/$(TARGET_COPY_OUT_SYSTEM)/app/ims/lib/arm64/libimsmedia_jni.so
 $(LOCAL_BUILT_MODULE): $(LOCAL_PATH)/Android.mk
 $(LOCAL_BUILT_MODULE):
 	$(hide) mkdir -p $(dir $@)
@@ -124,13 +124,13 @@
 	$(hide) ln -sf $(TARGET) $(SYMLINK)
 	$(hide) touch $@
 include $(CLEAR_VARS)
-LOCAL_MODULE := libimsmedia_jni_64.so
+LOCAL_MODULE := libimscamera_jni_64.so
 LOCAL_MODULE_CLASS := FAKE
 LOCAL_MODULE_TAGS := optional
 LOCAL_MODULE_OWNER := google
 include $(BUILD_SYSTEM)/base_rules.mk
-$(LOCAL_BUILT_MODULE): TARGET := /system/lib64/libimsmedia_jni.so
-$(LOCAL_BUILT_MODULE): SYMLINK := $(PRODUCT_OUT)/$(TARGET_COPY_OUT_SYSTEM)/app/ims/lib/arm64/libimsmedia_jni.so
+$(LOCAL_BUILT_MODULE): TARGET := /system/lib64/libimscamera_jni.so
+$(LOCAL_BUILT_MODULE): SYMLINK := $(PRODUCT_OUT)/$(TARGET_COPY_OUT_SYSTEM)/app/ims/lib/arm64/libimscamera_jni.so
 $(LOCAL_BUILT_MODULE): $(LOCAL_PATH)/Android.mk
 $(LOCAL_BUILT_MODULE):
 	$(hide) mkdir -p $(dir $@)
diff -r -u /nix/store/s4kp7rw8prpyla1i51mwpybxddm9id0l-vendor-files-crosshatch/vendor/google_devices/crosshatch/crosshatch-vendor-blobs.mk /nix/store/cvgzlrsgx5q7y6r5c4g8q1d8g5rfaaz0-vendor-files-crosshatch/vendor/google_devices/crosshatch/crosshatch-vendor-blobs.mk
--- /nix/store/s4kp7rw8prpyla1i51mwpybxddm9id0l-vendor-files-crosshatch/vendor/google_devices/crosshatch/crosshatch-vendor-blobs.mk	1969-12-31 19:00:01.000000000 -0500
+++ /nix/store/cvgzlrsgx5q7y6r5c4g8q1d8g5rfaaz0-vendor-files-crosshatch/vendor/google_devices/crosshatch/crosshatch-vendor-blobs.mk	1969-12-31 19:00:01.000000000 -0500
@@ -1917,6 +1917,6 @@
     vendor/google_devices/crosshatch/vendor/usr/keylayout/uinput-fpc.kl:$(TARGET_COPY_OUT_VENDOR)/usr/keylayout/uinput-fpc.kl:google
 
 PRODUCT_COPY_FILES += \
-    vendor/google_devices/crosshatch/proprietary/lib64/libimscamera_jni.so:$(TARGET_COPY_OUT_SYSTEM)/lib64/libimscamera_jni.so:google \
-    vendor/google_devices/crosshatch/proprietary/lib64/libimsmedia_jni.so:$(TARGET_COPY_OUT_SYSTEM)/lib64/libimsmedia_jni.so:google
+    vendor/google_devices/crosshatch/proprietary/lib64/libimsmedia_jni.so:$(TARGET_COPY_OUT_SYSTEM)/lib64/libimsmedia_jni.so:google \
+    vendor/google_devices/crosshatch/proprietary/lib64/libimscamera_jni.so:$(TARGET_COPY_OUT_SYSTEM)/lib64/libimscamera_jni.so:google
 
diff -r -u /nix/store/s4kp7rw8prpyla1i51mwpybxddm9id0l-vendor-files-crosshatch/vendor/google_devices/crosshatch/file_signatures.txt /nix/store/cvgzlrsgx5q7y6r5c4g8q1d8g5rfaaz0-vendor-files-crosshatch/vendor/google_devices/crosshatch/file_signatures.txt
--- /nix/store/s4kp7rw8prpyla1i51mwpybxddm9id0l-vendor-files-crosshatch/vendor/google_devices/crosshatch/file_signatures.txt	1969-12-31 19:00:01.000000000 -0500
+++ /nix/store/cvgzlrsgx5q7y6r5c4g8q1d8g5rfaaz0-vendor-files-crosshatch/vendor/google_devices/crosshatch/file_signatures.txt	1969-12-31 19:00:01.000000000 -0500
@@ -1,7 +1,7 @@
-8345c1f3ac20bb837205242c98220199f9bad051  vendor/google_devices/crosshatch/Android.mk
+d281c3810903ea5ce20f912d0e8c583a07cf3c72  vendor/google_devices/crosshatch/Android.mk
 fbf10b9c63fb463a489ec1391e4e645c9051092f  vendor/google_devices/crosshatch/AndroidBoardVendor.mk
 3b48261d31526a306ac5e88995dfa15a46a003f0  vendor/google_devices/crosshatch/BoardConfigVendorPartial.mk
-dc162d6488845bf6f2a9c6664a39077144f3b45c  vendor/google_devices/crosshatch/crosshatch-vendor-blobs.mk
+405a823e8196c78a0cd75ccad763e080a274146e  vendor/google_devices/crosshatch/crosshatch-vendor-blobs.mk
 ea7e24e47d58f37058be69ca04f53b71759e05a8  vendor/google_devices/crosshatch/proprietary/BoardConfigVendor.mk
 a5a36d68a748122424351a8ac1551ae3473245c4  vendor/google_devices/crosshatch/proprietary/app/QAS_DVC_MSP/QAS_DVC_MSP.apk
 0a7dd424060a4ffcd563f21d0ea5717969168377  vendor/google_devices/crosshatch/proprietary/app/QtiTelephonyService/QtiTelephonyService.apk
@@ -9,7 +9,7 @@
 3ab3c84390f16bd275b15bfbfac697e57ac38e84  vendor/google_devices/crosshatch/proprietary/app/embms/embms.apk
 8b1e29c553098c97b28b57dcd3488e015248fe61  vendor/google_devices/crosshatch/proprietary/app/ims/ims.apk
 5de4211aaf0d638964311e40b67999ccc932a08c  vendor/google_devices/crosshatch/proprietary/app/uceShimService/uceShimService.apk
-e5f16ac428fad1f230833b406a4443c238b5ea36  vendor/google_devices/crosshatch/proprietary/device-vendor.mk
+b9fe95a0c896fe44a6e880d39a5ce0394df77f8c  vendor/google_devices/crosshatch/proprietary/device-vendor.mk
 0454d4d27fb5bbe87c1d6ebd4e9432508de76c9b  vendor/google_devices/crosshatch/proprietary/etc/permissions/LteDirectDiscovery.xml
 a2bb4abefd281692e6af2c1c5785c09a5ab89703  vendor/google_devices/crosshatch/proprietary/etc/permissions/UimService.xml
 15831adf0e80243042b90c734eea0a68eb8ae9c9  vendor/google_devices/crosshatch/proprietary/etc/permissions/cneapiclient.xml
diff -r -u /nix/store/s4kp7rw8prpyla1i51mwpybxddm9id0l-vendor-files-crosshatch/vendor/google_devices/crosshatch/proprietary/device-vendor.mk /nix/store/cvgzlrsgx5q7y6r5c4g8q1d8g5rfaaz0-vendor-files-crosshatch/vendor/google_devices/crosshatch/proprietary/device-vendor.mk
--- /nix/store/s4kp7rw8prpyla1i51mwpybxddm9id0l-vendor-files-crosshatch/vendor/google_devices/crosshatch/proprietary/device-vendor.mk	1969-12-31 19:00:01.000000000 -0500
+++ /nix/store/cvgzlrsgx5q7y6r5c4g8q1d8g5rfaaz0-vendor-files-crosshatch/vendor/google_devices/crosshatch/proprietary/device-vendor.mk	1969-12-31 19:00:01.000000000 -0500
@@ -23,8 +23,8 @@
 
 # Prebuilt APKs libs symlinks from 'proprietary/app'
 PRODUCT_PACKAGES += \
-    libimscamera_jni_64.so \
-    libimsmedia_jni_64.so
+    libimsmedia_jni_64.so \
+    libimscamera_jni_64.so
 
 # Prebuilt APKs/JARs from 'proprietary/framework'
 PRODUCT_PACKAGES += \
```