### PR TITLE
taimen/walleye: Ignore odm/etc/NOTICE.xml.gz

### DIFF
--- a/taimen/config.json
+++ b/taimen/config.json
@@ -468,6 +468,7 @@
         "lib/soundfx/libvolumelistener.so",
         "odm/etc/build.prop",
         "odm/etc/group",
+        "odm/etc/NOTICE.xml.gz",
         "odm/etc/passwd"
       ]
     }

--- a/walleye/config.json
+++ b/walleye/config.json
@@ -468,6 +468,7 @@
         "lib/soundfx/libvolumelistener.so",
         "odm/etc/build.prop",
         "odm/etc/group",
+        "odm/etc/NOTICE.xml.gz",
         "odm/etc/passwd"
       ]
     }


### PR DESCRIPTION
Otherwise we encounter the following failure:
```
  FAILED: ninja: dependency cycle: out/target/product/taimen/vendor/odm/etc/NOTICE.xml.gz -> out/target/product/taimen/obj/NOTICE_ODM.xml.gz -> out/target/product/taimen/obj/NOTICE_ODM.xml -> out/target/product/taimen/vendor/odm/etc/NOTICE.xml.gz
```

Sorry my original PR missed this. I must have ignored it elsewhere and forgotten about it when I rebased.