### PR TITLE
add empty system_ext sections to walleye/taimen

### DIFF
--- a/taimen/config.json
+++ b/taimen/config.json
@@ -85,6 +85,8 @@
         "system/lib64/librcc.so",
         "system/lib64/vendor.qti.qcril.am@1.0.so"
       ],
+      "system_ext-bytecode": [],
+      "system_ext-other": [],
       "product-bytecode": [],
       "forced-modules": [
         "chre",

--- a/walleye/config.json
+++ b/walleye/config.json
@@ -85,6 +85,8 @@
         "system/lib64/librcc.so",
         "system/lib64/vendor.qti.qcril.am@1.0.so"
       ],
+      "system_ext-bytecode": [],
+      "system_ext-other": [],
       "product-bytecode": [],
       "forced-modules": [
         "chre",


### PR DESCRIPTION
commit for adding system-ext support doesn't play well with missing config entries. so add empty ones here. will make sure remaining devices have this entry as well.

```
[!] Vendor partition contains pre-optimized bytecode - not supported yet
Not aborting, TODO: FIX properly
jq: error (at /home/strcat/projects/grapheneos/android-prepare-vendor/taimen/config.json:476): Cannot iterate over null (null)
[-] json raw string array parse failed
jq: error (at /home/strcat/projects/grapheneos/android-prepare-vendor/taimen/config.json:476): Cannot iterate over null (null)
[-] json raw string array parse failed
jq: error (at /home/strcat/projects/grapheneos/android-prepare-vendor/taimen/config.json:476): Cannot iterate over null (null)
[-] json raw string array parse failed
jq: error (at /home/strcat/projects/grapheneos/android-prepare-vendor/taimen/config.json:476): Cannot iterate over null (null)
[-] json raw string array parse failed
```