### PR TITLE
Workaround for including .vintf files in PRODUCT_COPY_FILES

### DIFF
--- a/scripts/generate-vendor.sh
+++ b/scripts/generate-vendor.sh
@@ -480,6 +480,9 @@ gen_board_cfg_mk() {
       echo 'BOARD_SYSTEM_EXTIMAGE_FILE_SYSTEM_TYPE := ext4'
     fi
 
+    # Android 11 workaround for including .vintf files in PRODUCT_COPY_FILES
+    echo 'BUILD_BROKEN_VINTF_PRODUCT_COPY_FILES := true'
+
     # Update with user selected extra flags
     echo "$MK_FLAGS_LIST"
   } >> "$BOARD_CONFIG_VENDOR_MK"


### PR DESCRIPTION
Since our apv output is what causes the issue, apv should set `BUILD_BROKEN_VINTF_PRODUCT_COPY_FILES` so the user doesn't have to do it in their device source tree. Build tested working with taimen/walleye using an unmodified `device/google/wahoo` upstream.

CC @thestinger for https://github.com/GrapheneOS/device_google_wahoo/commit/46d0d05ce0e2e1d967cc894f5fbc6ae2e53c7bc3