### PR TITLE
taimen/walleye: fix camera

### DIFF
--- a/taimen/config.json
+++ b/taimen/config.json
@@ -383,7 +383,6 @@
         "lib/libgnss.so",
         "lib/libgps.utils.so",
         "lib/libgpu_tonemapper.so",
-        "lib/libhdrplusclient.so",
         "lib/libhidltransport.so",
         "lib/libhwbinder.so",
         "lib/libjson.so",

--- a/walleye/config.json
+++ b/walleye/config.json
@@ -383,7 +383,6 @@
         "lib/libgnss.so",
         "lib/libgps.utils.so",
         "lib/libgpu_tonemapper.so",
-        "lib/libhdrplusclient.so",
         "lib/libhidltransport.so",
         "lib/libhwbinder.so",
         "lib/libjson.so",


### PR DESCRIPTION
Should fix: https://github.com/GrapheneOS/os_issue_tracker/issues/318
Tested on `walleye` with help from @samueldr

The relevant error messages are these:
```
09-16 11:51:02.093 24111 24111 E QCamera3HWI: initHdrPlusClientLocked: Failed to create Easel manager client.
09-16 11:51:02.093 24111 24111 E QCamera3HWI: getCamInfo: initHdrPlusClientLocked failed: No such device (-19)
```

Previously, we didn't set `vendor-skip-files` for taimen / walleye, so we were using the prebuilt `vendor/lib/libhdrplusclient.so`.  See `hardware/google/easel/amber/camera/libhdrplusclient/Android.mk` which enables the "dummy implementation" of `libhdrplusclient` when built as part of AOSP.  However, this dummy implementation doesn't work.  Note that it returns `nullptr` from `EaselManagerClient::create()` in `EaselManagerClient.cpp`.  This causes the failure in `QCamera3HardwareInterface::initHdrPlusClientLocked()` in `hardware/qcom/camera/msm8998/QCamera2/HAL3/QCamera3HWI.cpp`

I also tried building `libhdrplusclient` with `-DUSE_DUMMY_IMPL=0` and linking against the prebuilt `libhdrplusclientimpl`. It doesn't compile since:
```
hardware/google/easel/amber/camera/libhdrplusclient/EaselManagerClient.cpp:24:10: fatal error: 'EaselManagerClientImpl.h' file not found
```
and that file is nowhere to be found.

It might be possible to patch `hardware/qcom/camera/msm8998/QCamera2` to work with the nullptr dummy implementation, or fix the dummy implementation itself, but I don't have the patience to do that for a device I don't even own.

So, this PR just uses the prebuilt `libhdrplusclient`, which already works fine.