### PR TITLE
Android 10 (sailfish): prevents generate-vendor.sh from failing when EXTRA_IMGS or OTA_IMGS is not defined

### DIFF
--- a/scripts/generate-vendor.sh
+++ b/scripts/generate-vendor.sh
@@ -1013,14 +1013,18 @@ update_ab_ota_partitions() {
   {
     echo "# Partitions to add in AB OTA images"
     echo 'AB_OTA_PARTITIONS += vendor \'
-    for partition in "${EXTRA_IMGS[@]}"
-    do
-      echo "    $partition \\"
-    done
-    for partition in "${OTA_IMGS[@]}"
-    do
-      echo "    $partition \\"
-    done
+    if [[ "$EXTRA_IMGS_LIST" != "" ]]; then
+      for partition in "${EXTRA_IMGS[@]}"
+      do
+        echo "    $partition \\"
+      done
+    fi
+    if [[ "$OTA_IMGS_LIST" != "" ]]; then
+      for partition in "${OTA_IMGS[@]}"
+      do
+        echo "    $partition \\"
+      done
+    fi
   }  >> "$outMk"
   strip_trail_slash_from_file "$outMk"
 }


### PR DESCRIPTION
In `generate-vendor.sh`, depending on the values of `EXTRA_IMGS_LIST` and `OTA_IMGS_LIST`, those variable would be defined or not. There are checks to make sure they are defined before using them, but such checks were missing at one place. This commit fixes this.

This error was detected when preparing vendors for sailfish (Android 10):

    ./execute-all.sh -d sailfish -b QP1A.191005.007.A3 -o /path/to/AOSP

Resulting error:

    scripts/generate-vendor.sh: line 1016: EXTRA_IMGS[@]: unbound variable