### PR TITLE
disable bytecode repair by default in api >= 30

### DIFF
--- a/execute-all.sh
+++ b/execute-all.sh
@@ -674,8 +674,11 @@ else
   # Default choices based on API level
   if [ "$API_LEVEL" -le 23 ]; then
     BYTECODE_REPAIR_METHOD="OAT2DEX"
-  elif [ "$API_LEVEL" -ge 24 ]; then
+  elif [ "$API_LEVEL" -ge 24 ] && [ "$API_LEVEL" -lt 30 ]; then
     BYTECODE_REPAIR_METHOD="OATDUMP"
+  elif [ "$API_LEVEL" -ge 30 ]; then
+    BYTECODE_REPAIR_METHOD="NONE"
+    FORCE_PREOPT=true
   fi
 fi
 


### PR DESCRIPTION
It doesn't appear we actually do any bytecode repair at this point (i.e. you'll see in output - `bytecode is not stripped - copying without changes`), but we still default to oatdump and download oatdump and dependencies from onedrive. This change would just skip bytecode repair (and therefore skip oatdump download) for anything api >= 30.

* Current code which defaults to `BYTECODE_REPAIR_METHOD="OATDUMP"`: `./execute-all.sh --debugfs -d crosshatch -b RP1A.200720.009 -o out/oatdump`
* Test with just `BYTECODE_REPAIR_METHOD="NONE"`: `./execute-all.sh --debugfs -d crosshatch -b RP1A.200720.009 -o out/none`. This resulted in a minor difference in generated Android.mk file with `LOCAL_DEX_PREOPT=false`. I don't really know if we want this enabled or disabled.
```
diff -qr none oatdump
Files none/crosshatch/rp1a.200720.009/vendor/google_devices/crosshatch/Android.mk and oatdump/crosshatch/rp1a.200720.009/vendor/google_devices/crosshatch/Android.mk differ
Files none/crosshatch/rp1a.200720.009/vendor/google_devices/crosshatch/file_signatures.txt and oatdump/crosshatch/rp1a.200720.009/vendor/google_devices/crosshatch/file_signatures.txt differ

diff none/crosshatch/rp1a.200720.009/vendor/google_devices/crosshatch/file_signatures.txt oatdump/crosshatch/rp1a.200720.009/vendor/google_devices/crosshatch/file_signatures.txt
2c2
< 735b593183cd49ef114aeaef3f4d7f1b677480d7  vendor/google_devices/crosshatch/Android.mk
---
> ddc39b26bdc6d88d0925aeb544e45e57ed5482e8  vendor/google_devices/crosshatch/Android.mk

diff none/crosshatch/rp1a.200720.009/vendor/google_devices/crosshatch/Android.mk oatdump/crosshatch/rp1a.200720.009/vendor/google_devices/crosshatch/Android.mk
23d22
< LOCAL_DEX_PREOPT := false
48d46
< LOCAL_DEX_PREOPT := false
61d58
< LOCAL_DEX_PREOPT := false
74d70
< LOCAL_DEX_PREOPT := false
88d83
< LOCAL_DEX_PREOPT := false
134d128
< LOCAL_DEX_PREOPT := false
146d139
< LOCAL_DEX_PREOPT := false
158d150
< LOCAL_DEX_PREOPT := false
172d163
< LOCAL_DEX_PREOPT := false
186d176
< LOCAL_DEX_PREOPT := false
198d187
< LOCAL_DEX_PREOPT := false
210d198
< LOCAL_DEX_PREOPT := false
222d209
< LOCAL_DEX_PREOPT := false
234d220
< LOCAL_DEX_PREOPT := false
246d231
< LOCAL_DEX_PREOPT := false
258d242
< LOCAL_DEX_PREOPT := false
```

* pr change with `BYTECODE_REPAIR_METHOD="NONE"` and `FORCE_PREOPT=true`: `./execute-all.sh --debugfs -d crosshatch -b RP1A.200720.009 -o out/none-forcepreopt`. This produced no differences in generated output.
```
diff -qr none-forcepreopt oatdump
```

this was an old image i tested on (`RP1A.200720.009`).. but also tested latest with crosshatch `RQ3A.210905.001` with same results.
